### PR TITLE
`-a``-r``-l`オプションを併用できるように実装

### DIFF
--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -21,6 +21,15 @@ S_IFBLK = '060000'.to_i(8)
 S_IFREG = '100000'.to_i(8)
 S_IFLNK = '120000'.to_i(8)
 S_IFSOCK = '140000'.to_i(8)
+CONV_MODE_FILE_TYPE_HASH = {
+  S_IFFIFO => 'p',
+  S_IFCHR => 'c',
+  S_IFDIR => 'd',
+  S_IFBLK => 'b',
+  S_IFREG => '-',
+  S_IFLNK => 'l',
+  S_IFSOCK => 's'
+}.freeze
 
 ##
 S_ISVTX = '001000'.to_i(8)
@@ -95,24 +104,8 @@ end
 
 def convert_strmode_file_type(mode)
   symbol = []
-
   # file type
-  case (mode & S_IFMT)
-  when S_IFFIFO
-    symbol << 'p'
-  when S_IFCHR
-    symbol << 'c'
-  when S_IFDIR
-    symbol << 'd'
-  when S_IFBLK
-    symbol << 'b'
-  when S_IFREG
-    symbol << '-'
-  when S_IFLNK
-    symbol << 'l'
-  when S_IFSOCK
-    symbol << 's'
-  end
+  symbol << CONV_MODE_FILE_TYPE_HASH[mode & S_IFMT]
 end
 
 def convert_strmode_user(mode)

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -69,10 +69,17 @@ def parse_options
   options
 end
 
-def show_files(files, len)
-  files.transpose.map do |rows|
+def show_normal_format_files(files)
+  max_file_len = files.max_by(&:length).length
+  sliced_files = []
+  files.each_slice((files.size.to_f / COLUMN_SIZE).ceil(0)) { |f| sliced_files << f }
+
+  # Array#transposeのためにsliced_filesの要素数を揃える
+  (sliced_files.first.size - sliced_files.last.size).times { sliced_files.last << nil }
+
+  sliced_files.transpose.map do |rows|
     rows.map do |file|
-      print "#{file&.ljust(len)}  "
+      print "#{file&.ljust(max_file_len)}  "
     end
     print "\n"
   end
@@ -166,18 +173,11 @@ end
 def ls
   options = parse_options
   files = Dir.glob('*')
-  max_file_len = files.max_by(&:length).length
 
   if options['-l']
     show_long_listing_format_files(files)
   else
-    sliced_files = []
-    files.each_slice((files.size.to_f / COLUMN_SIZE).ceil(0)) { |f| sliced_files << f }
-
-    # Array#transposeのためにsliced_filesの要素数を揃える
-    (sliced_files.first.size - sliced_files.last.size).times { sliced_files.last << nil }
-
-    show_files(sliced_files, max_file_len)
+    show_normal_format_files(files)
   end
 end
 

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -146,7 +146,7 @@ def show_long_listing_format_files(files)
 
   puts "total #{count_blocks(files)}"
 
-  files.map do |file|
+  files.each do |file|
     print "#{convert_strmode(File.stat(file).mode)} "
     print "#{File.stat(file).nlink.to_s.rjust(max_nlink_digits)} "
     print "#{Etc.getpwuid(File.stat(file).uid).name.rjust(max_username_length)}  "

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -4,7 +4,53 @@
 
 # frozen_string_literal: true
 
+# require
+require 'date'
+require 'etc'
+require 'optparse'
+
+# const define
 COLUMN_SIZE = 3
+
+## file type
+S_IFMT = '170000'.to_i(8)
+S_IFFIFO = '010000'.to_i(8)
+S_IFCHR = '020000'.to_i(8)
+S_IFDIR = '040000'.to_i(8)
+S_IFBLK = '060000'.to_i(8)
+S_IFREG = '100000'.to_i(8)
+S_IFLNK = '120000'.to_i(8)
+S_IFSOCK = '140000'.to_i(8)
+
+##
+S_ISVTX = '001000'.to_i(8)
+S_ISGID = '002000'.to_i(8)
+S_ISUID = '004000'.to_i(8)
+
+## user
+S_IRUSR = '000400'.to_i(8)
+S_IWUSR = '000200'.to_i(8)
+S_IXUSR = '000100'.to_i(8)
+
+## group
+S_IRGRP = '000040'.to_i(8)
+S_IWGRP = '000020'.to_i(8)
+S_IXGRP = '000010'.to_i(8)
+
+## other
+S_IROTH = '000004'.to_i(8)
+S_IWOTH = '000002'.to_i(8)
+S_IXOTH = '000001'.to_i(8)
+
+def parse_options
+  options = {}
+  opt = OptionParser.new
+
+  opt.on('-l') { |v| options['-l'] = v }
+  opt.parse!(ARGV)
+
+  options
+end
 
 def show_files(files, len)
   files.transpose.map do |rows|
@@ -15,17 +61,165 @@ def show_files(files, len)
   end
 end
 
+def count_blocks(files)
+  sum = 0
+  files.map do |file|
+    sum += File.stat(file).blocks
+  end
+  sum
+end
+
+def convert_strmode_file_type(mode)
+  symbol = []
+
+  # file type
+  case (mode & S_IFMT)
+  when S_IFFIFO
+    symbol << 'p'
+  when S_IFCHR
+    symbol << 'c'
+  when S_IFDIR
+    symbol << 'd'
+  when S_IFBLK
+    symbol << 'b'
+  when S_IFREG
+    symbol << '-'
+  when S_IFLNK
+    symbol << 'l'
+  when S_IFSOCK
+    symbol << 's'
+  end
+end
+
+def convert_strmode_user(mode)
+  symbol = []
+
+  # user
+  symbol << if (mode & S_IRUSR).zero?
+              '-'
+            else
+              'r'
+            end
+  symbol << if (mode & S_IWUSR).zero?
+              '-'
+            else
+              'w'
+            end
+
+  case (mode & (S_IXUSR | S_ISUID))
+  when 0
+    symbol << '-'
+  when S_IXUSR
+    symbol << 'x'
+  when S_ISUID
+    symbol << 'S'
+  when S_IXUSR | S_ISUID
+    symbol << 's'
+  end
+end
+
+def convert_strmode_group(mode)
+  symbol = []
+
+  # group
+  symbol << if (mode & S_IRGRP).zero?
+              '-'
+            else
+              'r'
+            end
+
+  symbol << if (mode & S_IWGRP).zero?
+              '-'
+            else
+              'w'
+            end
+
+  case (mode & (S_IXGRP | S_ISGID))
+  when 0
+    symbol << '-'
+  when S_IXGRP
+    symbol << 'x'
+  when S_ISGID
+    symbol << 'S'
+  when S_IXGRP | S_ISGID
+    symbol << 's'
+  end
+end
+
+def convert_strmode_other(mode)
+  symbol = []
+  # other
+  symbol << if (mode & S_IROTH).zero?
+              '-'
+            else
+              'r'
+            end
+
+  symbol << if (mode & S_IWOTH).zero?
+              '-'
+            else
+              'w'
+            end
+
+  case (mode & (S_IXOTH | S_ISVTX))
+  when 0
+    symbol << '-'
+  when S_IXOTH
+    symbol << 'x'
+  when S_ISGID
+    symbol << 'T'
+  when S_IXOTH | S_ISVTX
+    symbol << 't'
+  end
+end
+
+def convert_strmode(mode)
+  symbol = convert_strmode_file_type(mode), convert_strmode_user(mode), convert_strmode_group(mode), convert_strmode_other(mode)
+  symbol.join
+end
+
+def show_long_listing_format_files(files)
+  # 列整形用
+  max_nlink_digits = File.stat(files.max_by { |file| File.stat(file).nlink }).size.to_s.length
+  max_username_length = Etc.getpwuid(File.stat(files.max_by { |file| Etc.getpwuid(File.stat(file).uid).name }).uid).name.length
+  max_groupname_length = Etc.getgrgid(File.stat(files.max_by { |file| Etc.getgrgid(File.stat(file).gid).name }).gid).name.length
+  max_size_digits = File.stat(files.max_by { |file| File.stat(file).size }).size.to_s.length
+
+  puts "total #{count_blocks(files)}"
+
+  files.map do |file|
+    print "#{convert_strmode(File.stat(file).mode)} "
+    print "#{File.stat(file).nlink.to_s.rjust(max_nlink_digits)} "
+    print "#{Etc.getpwuid(File.stat(file).uid).name.rjust(max_username_length)}  "
+    print "#{Etc.getgrgid(File.stat(file).gid).name.rjust(max_groupname_length)}  "
+    print "#{File.stat(file).size.to_s.rjust(max_size_digits)} "
+    time_format = if Date.today.year == File.stat(file).mtime.year
+                    '%_m %_d %H:%M'
+                  else
+                    '%_m %_d  %Y'
+                  end
+    print "#{File.stat(file).mtime.strftime(time_format)} "
+    print file
+    print "\n"
+  end
+end
+
 def ls
+  options = parse_options
   files = Dir.glob('*')
   max_file_len = files.max_by(&:length).length
 
-  sliced_files = []
-  files.each_slice((files.size.to_f / COLUMN_SIZE).ceil(0)) { |f| sliced_files << f }
+  if options['-l']
+    show_long_listing_format_files(files)
+  else
+    sliced_files = []
+    files.each_slice((files.size.to_f / COLUMN_SIZE).ceil(0)) { |f| sliced_files << f }
 
-  # Array#transposeのためにsliced_filesの要素数を揃える
-  (sliced_files.first.size - sliced_files.last.size).times { sliced_files.last << nil }
+    # Array#transposeのためにsliced_filesの要素数を揃える
+    (sliced_files.first.size - sliced_files.last.size).times { sliced_files.last << nil }
 
-  show_files(sliced_files, max_file_len)
+    show_files(sliced_files, max_file_len)
+  end
 end
 
 ls

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -4,7 +4,18 @@
 
 # frozen_string_literal: true
 
+require 'optparse'
 COLUMN_SIZE = 3
+
+def parse_options
+  options = {}
+  opt = OptionParser.new
+
+  opt.on('-r') { |v| options['-r'] = v }
+  opt.parse!(ARGV)
+
+  options
+end
 
 def show_files(files, len)
   files.transpose.map do |rows|
@@ -16,7 +27,9 @@ def show_files(files, len)
 end
 
 def ls
+  options = parse_options
   files = Dir.glob('*')
+  files.reverse! if options['-r']
   max_file_len = files.max_by(&:length).length
 
   sliced_files = []

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -110,56 +110,25 @@ end
 
 def convert_strmode_user(mode)
   symbol = []
-
   # user
-  symbol << if (mode & S_IRUSR).zero?
-              '-'
-            else
-              'r'
-            end
-  symbol << if (mode & S_IWUSR).zero?
-              '-'
-            else
-              'w'
-            end
-
+  symbol << ((mode & S_IRUSR).zero? ? '-' : 'r')
+  symbol << ((mode & S_IWUSR).zero? ? '-' : 'w')
   symbol << CONV_MODE_USR_HASH[mode & (S_IXUSR | S_ISUID)]
 end
 
 def convert_strmode_group(mode)
   symbol = []
-
   # group
-  symbol << if (mode & S_IRGRP).zero?
-              '-'
-            else
-              'r'
-            end
-
-  symbol << if (mode & S_IWGRP).zero?
-              '-'
-            else
-              'w'
-            end
-
+  symbol << ((mode & S_IRGRP).zero? ? '-' : 'r')
+  symbol << ((mode & S_IWGRP).zero? ? '-' : 'w')
   symbol << CONV_MODE_GRP_HASH[mode & (S_IXGRP | S_ISGID)]
 end
 
 def convert_strmode_other(mode)
   symbol = []
   # other
-  symbol << if (mode & S_IROTH).zero?
-              '-'
-            else
-              'r'
-            end
-
-  symbol << if (mode & S_IWOTH).zero?
-              '-'
-            else
-              'w'
-            end
-
+  symbol << ((mode & S_IROTH).zero? ? '-' : 'r')
+  symbol << ((mode & S_IWOTH).zero? ? '-' : 'w')
   symbol << CONV_MODE_OTH_HASH[mode & (S_IXOTH | S_ISVTX)]
 end
 

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -21,7 +21,7 @@ S_IFBLK = '060000'.to_i(8)
 S_IFREG = '100000'.to_i(8)
 S_IFLNK = '120000'.to_i(8)
 S_IFSOCK = '140000'.to_i(8)
-CONV_MODE_FILE_TYPE_HASH = {
+MODE_FILE_TYPE_TABLE = {
   S_IFFIFO => 'p',
   S_IFCHR => 'c',
   S_IFDIR => 'd',
@@ -40,7 +40,7 @@ S_ISUID = '004000'.to_i(8)
 S_IRUSR = '000400'.to_i(8)
 S_IWUSR = '000200'.to_i(8)
 S_IXUSR = '000100'.to_i(8)
-CONV_MODE_USR_HASH = {
+MODE_USR_TABLE = {
   0 => '-',
   S_IXUSR => 'x',
   S_ISUID => 'S',
@@ -51,7 +51,7 @@ CONV_MODE_USR_HASH = {
 S_IRGRP = '000040'.to_i(8)
 S_IWGRP = '000020'.to_i(8)
 S_IXGRP = '000010'.to_i(8)
-CONV_MODE_GRP_HASH = {
+MODE_GRP_TABLE = {
   0 => '-',
   S_IXGRP => 'x',
   S_ISGID => 'S',
@@ -61,7 +61,7 @@ CONV_MODE_GRP_HASH = {
 S_IROTH = '000004'.to_i(8)
 S_IWOTH = '000002'.to_i(8)
 S_IXOTH = '000001'.to_i(8)
-CONV_MODE_OTH_HASH = {
+MODE_OTH_TABLE = {
   0 => '-',
   S_IXOTH => 'x',
   S_ISVTX => 'T',
@@ -105,7 +105,7 @@ end
 def convert_strmode_file_type(mode)
   symbol = []
   # file type
-  symbol << CONV_MODE_FILE_TYPE_HASH[mode & S_IFMT]
+  symbol << MODE_FILE_TYPE_TABLE[mode & S_IFMT]
 end
 
 def convert_strmode_user(mode)
@@ -113,7 +113,7 @@ def convert_strmode_user(mode)
   # user
   symbol << ((mode & S_IRUSR).zero? ? '-' : 'r')
   symbol << ((mode & S_IWUSR).zero? ? '-' : 'w')
-  symbol << CONV_MODE_USR_HASH[mode & (S_IXUSR | S_ISUID)]
+  symbol << MODE_USR_TABLE[mode & (S_IXUSR | S_ISUID)]
 end
 
 def convert_strmode_group(mode)
@@ -121,7 +121,7 @@ def convert_strmode_group(mode)
   # group
   symbol << ((mode & S_IRGRP).zero? ? '-' : 'r')
   symbol << ((mode & S_IWGRP).zero? ? '-' : 'w')
-  symbol << CONV_MODE_GRP_HASH[mode & (S_IXGRP | S_ISGID)]
+  symbol << MODE_GRP_TABLE[mode & (S_IXGRP | S_ISGID)]
 end
 
 def convert_strmode_other(mode)
@@ -129,7 +129,7 @@ def convert_strmode_other(mode)
   # other
   symbol << ((mode & S_IROTH).zero? ? '-' : 'r')
   symbol << ((mode & S_IWOTH).zero? ? '-' : 'w')
-  symbol << CONV_MODE_OTH_HASH[mode & (S_IXOTH | S_ISVTX)]
+  symbol << MODE_OTH_TABLE[mode & (S_IXOTH | S_ISVTX)]
 end
 
 def convert_strmode(mode)
@@ -152,11 +152,7 @@ def show_long_listing_format_files(files)
     print "#{Etc.getpwuid(File.stat(file).uid).name.rjust(max_username_length)}  "
     print "#{Etc.getgrgid(File.stat(file).gid).name.rjust(max_groupname_length)}  "
     print "#{File.stat(file).size.to_s.rjust(max_size_digits)} "
-    time_format = if Date.today.year == File.stat(file).mtime.year
-                    '%_m %_d %H:%M'
-                  else
-                    '%_m %_d  %Y'
-                  end
+    time_format = (Date.today.year == File.stat(file).mtime.year ? '%_m %_d %H:%M' : '%_m %_d  %Y')
     print "#{File.stat(file).mtime.strftime(time_format)} "
     print file
     print "\n"

--- a/05.ls/lib/ls.rb
+++ b/05.ls/lib/ls.rb
@@ -31,16 +31,33 @@ S_ISUID = '004000'.to_i(8)
 S_IRUSR = '000400'.to_i(8)
 S_IWUSR = '000200'.to_i(8)
 S_IXUSR = '000100'.to_i(8)
+CONV_MODE_USR_HASH = {
+  0 => '-',
+  S_IXUSR => 'x',
+  S_ISUID => 'S',
+  S_IXUSR | S_ISUID => 's'
+}.freeze
 
 ## group
 S_IRGRP = '000040'.to_i(8)
 S_IWGRP = '000020'.to_i(8)
 S_IXGRP = '000010'.to_i(8)
-
+CONV_MODE_GRP_HASH = {
+  0 => '-',
+  S_IXGRP => 'x',
+  S_ISGID => 'S',
+  S_IXGRP | S_ISGID => 's'
+}.freeze
 ## other
 S_IROTH = '000004'.to_i(8)
 S_IWOTH = '000002'.to_i(8)
 S_IXOTH = '000001'.to_i(8)
+CONV_MODE_OTH_HASH = {
+  0 => '-',
+  S_IXOTH => 'x',
+  S_ISVTX => 'T',
+  S_IXOTH | S_ISVTX => 't'
+}.freeze
 
 def parse_options
   options = {}
@@ -106,16 +123,7 @@ def convert_strmode_user(mode)
               'w'
             end
 
-  case (mode & (S_IXUSR | S_ISUID))
-  when 0
-    symbol << '-'
-  when S_IXUSR
-    symbol << 'x'
-  when S_ISUID
-    symbol << 'S'
-  when S_IXUSR | S_ISUID
-    symbol << 's'
-  end
+  symbol << CONV_MODE_USR_HASH[mode & (S_IXUSR | S_ISUID)]
 end
 
 def convert_strmode_group(mode)
@@ -134,16 +142,7 @@ def convert_strmode_group(mode)
               'w'
             end
 
-  case (mode & (S_IXGRP | S_ISGID))
-  when 0
-    symbol << '-'
-  when S_IXGRP
-    symbol << 'x'
-  when S_ISGID
-    symbol << 'S'
-  when S_IXGRP | S_ISGID
-    symbol << 's'
-  end
+  symbol << CONV_MODE_GRP_HASH[mode & (S_IXGRP | S_ISGID)]
 end
 
 def convert_strmode_other(mode)
@@ -161,16 +160,7 @@ def convert_strmode_other(mode)
               'w'
             end
 
-  case (mode & (S_IXOTH | S_ISVTX))
-  when 0
-    symbol << '-'
-  when S_IXOTH
-    symbol << 'x'
-  when S_ISGID
-    symbol << 'T'
-  when S_IXOTH | S_ISVTX
-    symbol << 't'
-  end
+  symbol << CONV_MODE_OTH_HASH[mode & (S_IXOTH | S_ISVTX)]
 end
 
 def convert_strmode(mode)


### PR DESCRIPTION
これまで実装した`-a``-r``-l`オプションを併用できるようにコードをまとめた。